### PR TITLE
Bring the schedule back

### DIFF
--- a/_includes/DaSH_schedule.html
+++ b/_includes/DaSH_schedule.html
@@ -1,0 +1,55 @@
+<div class="row">
+  <div class="col-md-6">
+    <h3>Day 1: Thursday March 9th</h3>
+   <table class="table table-striped">
+      <tr> <td>09:00</td>  <td>Drop-in session: A clinic to assist with the setup of your computer. We strongly recommend you complete the setup session and have your computer ready for the lesson. </td> </tr>
+      <tr> <td>10:00</td>  <td>Building Programs with Python</td> </tr>
+      <tr> <td>11:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>12:00</td>  <td>Building Programs with Python (Continued)</td> </tr>
+      <tr> <td>13:00</td>  <td>Lunch break</td> </tr>
+      <tr> <td>14:00</td>  <td>Building Programs with Python (Continued)</td> </tr>
+      <tr> <td>15:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>16:00</td>  <td>Building Programs with Python (Continued)</td> </tr>
+      <tr> <td>17:00</td>  <td>Wrap-up</td> </tr>
+    </table>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-6">
+     <h3>Day 2: Friday March 10th (by <a href="https://healthbioscienceideas.github.io/">IDEAS</a>)</h3>
+    <table class="table table-striped">
+      <tr> <td>09:00</td>  <td>Drop-in session: A clinic to assist with the setup of your computer. We strongly recommend you complete the setup session and have your computer ready for the lesson.</td> </tr>
+      <tr> <td>10:00</td>  <td>Introduction to 2D and 3D Image Analysis </td> </tr>
+      <tr> <td>11:00</td>  <td>Medical Images from the Scanner to computer</td> </tr>
+      <tr> <td>11:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>12:00</td>  <td>MRI modalities (Continued)</td> </tr>
+      <tr> <td>12:30</td>  <td>Introduction to registration</td> </tr>
+      <tr> <td>13:00</td>  <td>Lunch break</td> </tr>
+      <tr> <td>14:00</td>  <td>Structural MRI (sMRI)</td> </tr>
+      <tr> <td>15:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>16:00</td>  <td>sMRI: Segmentation and Parcellation</td> </tr>
+      <tr> <td>16:20</td>  <td>sMRI: Quality control</td> </tr>
+      <tr> <td>16:45</td>  <td>Statistical analysis and reproducibility</td> </tr>
+      <tr> <td>17:00</td>  <td>Wrap-up</td> </tr>
+    </table>
+  </div>
+  <div class="row">
+  <div class="col-md-6">
+    <h3> Monday March 13th  : Set up libraries for Day 3: venue TBC </h3>
+    </div>
+  <div class="row">
+  <div class="col-md-6">
+       <h3> Day 3: Tuesday March 14th (by <a href="https://learntodiscover.ai/">Learn to discover</a>) </h3>
+    <table class="table table-striped">
+      <tr> <td>09:00</td>  <td>Drop-in session</td> </tr>
+      <tr> <td>10:00</td>  <td>Analysing microscopic data</td> </tr>
+      <tr> <td>11:30</td>  <td>Morning break</td> </tr>
+      <tr> <td>12:00</td>  <td>Analysing microscopic data (Continued)</td> </tr>
+      <tr> <td>13:00</td>  <td>Lunch break</td> </tr>
+      <tr> <td>14:00</td>  <td>Cell segmentation</td> </tr>
+      <tr> <td>15:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>16:00</td>  <td>Clustering Images</td> </tr>
+      <tr> <td>17:00</td>  <td>Wrap-up</td> </tr>
+    </table>
+  </div>
+</div>

--- a/index.md
+++ b/index.md
@@ -360,16 +360,7 @@ of code below the Schedule `<h2>` header below with
 
 <h2 id="schedule">Schedule</h2>
 
-{% if site.carpentry == "swc" %}
 {% include swc/schedule.html %}
-{% elsif site.carpentry == "dc" %}
-{% include dc/schedule.html %}
-{% elsif site.carpentry == "lc" %}
-{% include lc/schedule.html %}
-{% elsif site.carpentry == "incubator" %}
-This workshop is teaching a lesson in [The Carpentries Incubator](https://carpentries-incubator.org/).
-Please check [the lesson homepage]({{ site.incubator_lesson_site }}) for a list of lesson sections and estimated timings.
-{% endif %}
 
 {% comment %}
 Edit/replace the text above if you want to include a schedule table.

--- a/index.md
+++ b/index.md
@@ -360,7 +360,7 @@ of code below the Schedule `<h2>` header below with
 
 <h2 id="schedule">Schedule</h2>
 
-{% include swc/schedule.html %}
+{% include DaSH_schedule.html %}
 
 {% comment %}
 Edit/replace the text above if you want to include a schedule table.


### PR DESCRIPTION
Was getting a few pings from potential attendees saying the schedule had gone missing.

Changing the workshop type metadata to _not_ be `swc` means that the schedule was no longer displayed: the `_includes/swc/schedule.html` file is only displayed if the workshop flavour/type is set to `swc`, and our custom schedule was saved in `_includes/swc/schedule.html` rather than a custom schedule file.

I've added `DaSH_schedue.html` and pointed `index.md` to this file in the schedule section. The website should now render the schedule again.
